### PR TITLE
Japerry911/imp/v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # kestra-go
 
+### Summary
+
 This is the unofficial Kestra GoLang support module. 
 
 Currently this module's functionality includes allowing users to log messages with either TRACE, DEBUG, INFO, WARNING, ERROR, or CRTIICAL level and it'll log in a format that is understandable by your Kestra instance.
 
 The roadmap for this package to add better documentation and unit tests in the near future, and also adding the ability to send outputs to your Kestra instance. 
+
+### Installation
+
+`go get -u github.com/japerry911/kestra-go@v0.1.0`

--- a/kestra.go
+++ b/kestra.go
@@ -57,14 +57,10 @@ func (k *KestraLogger) Info(message string) {
 	k.logMessage("INFO", message)
 }
 
-func (k *KestraLogger) Warning(message string) {
-	k.logMessage("WARNING", message)
+func (k *KestraLogger) Warn(message string) {
+	k.logMessage("WARN", message)
 }
 
 func (k *KestraLogger) Error(message string) {
 	k.logMessage("ERROR", message)
-}
-
-func (k *KestraLogger) Critical(message string) {
-	k.logMessage("CRITICAL", message)
 }


### PR DESCRIPTION
- fix and changing `WARNING` to WARN` 
- remove `CRITICAL` , not handled in Kestra instance
- add documentation for installation `go get -u ...`